### PR TITLE
Fix Zoom Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ CDF Special Interest Group - *MLOps*
 - Mail list: https://lists.cd.foundation/g/sig-mlops   sig-mlops@lists.cd.foundation
 - Meeting minutes, agenda, and documentation: https://github.com/cdfoundation/sig-mlops
 
-The MLOps SIG meets every other week at 9:30 AM Pacific, on Thursdays -- [Zoom Meeting Link] (https://zoom.us/j/667125842)
+The MLOps SIG meets every other week at 9:30 AM Pacific, on Thursdays -- [Zoom Meeting Link](https://zoom.us/j/667125842)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,4 @@ CDF Special Interest Group - *MLOps*
 - Mail list: https://lists.cd.foundation/g/sig-mlops   sig-mlops@lists.cd.foundation
 - Meeting minutes, agenda, and documentation: https://github.com/cdfoundation/sig-mlops
 
-The MLOps SIG meets every other week at 9:30 AM Pacific, on Thursdays
-
-Download this meeting invite to add to your calendar: https://zoom.us/meeting/u5Iqduutpj8o7fVIT1pePLk5wv4H9XpojQ/ics
+The MLOps SIG meets every other week at 9:30 AM Pacific, on Thursdays -- [Zoom Meeting Link] (https://zoom.us/j/667125842)


### PR DESCRIPTION
The current calendar does not work -- at least temporarily we should make the zoom meeting link easy to find.