### PR TITLE
Update MLOpsRoadmap2022.md

### DIFF
--- a/roadmap/2022/MLOpsRoadmap2022.md
+++ b/roadmap/2022/MLOpsRoadmap2022.md
@@ -389,6 +389,16 @@ Compliance requires:<br/>
 Government agencies, third party accreditation businesses and their subcontractors are required to have access to confidential intellectual property.<br/><br/>Surveillance authorities shall be granted full access to the training, validation and testing datasets used.
 </td>
 </tr>  
+<tr> 
+   <td>Providing mechanisms to treat ML models as part of the broader product/system in which they reside, rather than as independent products.</td>
+   <td>While significantly more complex in practice, at the simplest level, an ML model can be thought of as a function that takes a set of data inputs and produces a data output (prediction).  ML predictions are always exposed within the context of a broader user experience (interface), whether that experience is an application, report, or other UI/UX.  Futher complicating the challenge is that sometimes multiple ML models are used in a single user-facing feature or a single ML model is used in multiple user-facing features.<br/>
+   Specific challenges include:<br/>
+&nbsp &nbsp- Associating specific ML assets with the end system(s)/application(s) in which their predictions are used (both for auditability purposes and practical purposes such as release coordination)<br/>
+&nbsp &nbsp- Associating multiple ML assets that depend upon each other<br/>
+&nbsp &nbsp- Enabling re-use of ML assets across multiple discrete systems/applications<br/>
+&nbsp &nbsp- Testing, releasing, and deploying ML assets in tandem with their system/application’s test, release and deployment schedule<br/>
+</td>
+</tr>  
 </table>
 
 <br>
@@ -547,6 +557,16 @@ Solutions should provide the ability to specify guardrail metrics and facilitate
     <td>Government regulation of AI</td>
     <td>Proposed regulation creates an urgent requirement for the implementation of many of the technology requirements outlined in the roadmap as existing approaches will cease to be viable upon introduction. This in turn also introduces the need to provide traceable reporting to third parties whilst protecting intellectual property as part of the daily function of regulatory compliance.</td>  
   </tr>
+
+  <tr> 
+   <td>Providing mechanisms to treat ML models as part of the broader product/system in which they reside, rather than as independent products.</td>
+   <td>Tooling should enable models (and their supporting assets) to be distributed as reusable components within a larger system/application (similar to dependency management for software).<br/><br/>
+Tooling should enable explicit dependency management between:<br/>
+&nbsp &nbsp- Models that depend upon other models<br/>
+&nbsp &nbsp- Applications that depend upon models<br/><br/>
+While covered in detail elsewhere in this roadmap, a specific requirement here is that tooling enables the same release and deployment process for software and ML assets that are used together.
+</td>
+</tr>
   </table>
 
 <br>


### PR DESCRIPTION
After discussion with @tdcox and @AlmogBaku , proposing a specific challenge around the fact that predictions from ML models are not (almost) never used as stand-alone outputs themselves, but rather, these predictions are embedded within other products (apps, reports, etc).

Following how the rest of the guide is written, I have avoiding naming ML assets or using any vendor specific terminology and tried to write that language such that it was focused on ops (e.g., it was relevant no matter the underlying ML approach used).

I believe a complete solution must address these challenges.  